### PR TITLE
Fix multiple issues in sitemap generation

### DIFF
--- a/ckanext/sitemap/controller.py
+++ b/ckanext/sitemap/controller.py
@@ -14,48 +14,56 @@ SITEMAP_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
 
 XHTML_NS = "http://www.w3.org/1999/xhtml"
 
-log = logging.getLogger(__file__)
+log = logging.getLogger(__name__)
 
 locales = config.get('ckan.locales_offered', '').split()
 
+default_locale = config.get('ckan.locale_default', 'en')
+
+
+def locale_urls_for(*args, **kwargs):
+    '''
+    Create URLs for all supported locales.
+
+    Works like ``ckan.lib.helpers.url_for``, but instead of returning a
+    single URL returns a dict that maps each offered locale to the
+    corresponding URL.
+    '''
+    # Omit locale code in default locale
+    urls = {default_locale: url_for(*args, **kwargs)}
+    for locale in locales:
+        if locale != default_locale:
+            urls[locale] = url_for(*args, locale=locale, **kwargs)
+    return urls
+
 
 class SitemapController(BaseController):
-
-    @staticmethod
-    def _create_language_alternatives(link, url):
-        '''
-        Create links (elements) for every language in locales_offered in .ini file
-        :param link: string containing the link, eg. /dataset/xyz
-        :param url: root node
-        '''
-        for lang in locales:
-            attrib = {"rel": "alternate", "hreflang": lang, "href":
-                      config.get('ckan.site_url') + '/' + lang + link}
-            etree.SubElement(url, '{http://www.w3.org/1999/xhtml}link', attrib)
 
     @beaker_cache(expire=3600*24, type="dbm", invalidate_on_startup=True)
     def _render_sitemap(self):
         root = etree.Element("urlset", nsmap={None: SITEMAP_NS, 'xhtml': XHTML_NS})
         pkgs = Session.query(Package).filter(Package.type=='dataset').filter(Package.private!=True).\
             filter(Package.state=='active').all()
-        log.debug(pkgs)
         for pkg in pkgs:
-            url = etree.SubElement(root, 'url')
-            loc = etree.SubElement(url, 'loc')
-            pkg_url = url_for(controller='package', action="read", id=pkg.name)
-            loc.text = config.get('ckan.site_url') + pkg_url
-            lastmod = etree.SubElement(url, 'lastmod')
-            lastmod.text = pkg.latest_related_revision.timestamp.strftime('%Y-%m-%d')
-            self._create_language_alternatives(pkg_url, url)
-            # for res in pkg.resources:
-            #     url = etree.SubElement(root, 'url')
-            #     loc = etree.SubElement(url, 'loc')
-            #     loc.text = config.get('ckan.site_url') + url_for(controller="package", action="resource_read",
-            #                                                      id=pkg.name, resource_id=res.id)
-            #     lastmod = etree.SubElement(url, 'lastmod')
-            #     self._create_language_alternatives(url_for(controller="package", action="resource_read",
-            #                                                id=pkg.name, resource_id=res.id), url)
-            #     lastmod.text = res.created.strftime('%Y-%m-%d')
+            locale_urls = locale_urls_for(controller='package', action='read',
+                                          id=pkg.name, qualified=True)
+            lastmod_text = pkg.metadata_modified.strftime('%Y-%m-%d')
+            # We need to create a separate <url> element for each locale's URL,
+            # see https://support.google.com/webmasters/answer/2620865
+            for main_locale, main_url in locale_urls.iteritems():
+                url = etree.SubElement(root, 'url')
+                loc = etree.SubElement(url, 'loc')
+                loc.text = main_url
+                lastmod = etree.SubElement(url, 'lastmod')
+                lastmod.text = lastmod_text
+                for locale, locale_url in locale_urls.iteritems():
+                    attrib = {
+                        "rel": "alternate",
+                        "hreflang": locale,
+                        "href": locale_url,
+                    }
+                    etree.SubElement(url, '{http://www.w3.org/1999/xhtml}link',
+                                     attrib)
         response.headers['Content-type'] = 'text/xml'
         return etree.tostring(root, pretty_print=True)
 


### PR DESCRIPTION
This PR fixes multiple issues w.r.t. sitemap generation and locales:
- Omit locale code from default locale (use canonical URL)
- Add a separate `<url>` element for each locale and URL, see https://support.google.com/webmasters/answer/2620865.
- Use `ckan.lib.helpers.url_for` to construct URLs so that the [`ckan.root_path`](http://docs.ckan.org/en/latest/maintaining/configuration.html#ckan-root-path) setting is taken into account.

By the way, running the tests against CKAN's `master` fails because the tests have been reorganized in CKAN core. You might want to consider setting up a CI account (e.g. on Travis or CircleCI) to continuously test against CKAN's `master`.
